### PR TITLE
feat: add signer adapter

### DIFF
--- a/packages/common/src/adapters/AbstractProviderAdapter.ts
+++ b/packages/common/src/adapters/AbstractProviderAdapter.ts
@@ -1,3 +1,4 @@
+import { AbstractSigner } from './AbstractSigner'
 import type { AdapterTypes, AdapterUtils } from './types'
 
 /**
@@ -10,6 +11,8 @@ export abstract class AbstractProviderAdapter<T extends AdapterTypes = AdapterTy
 
   public ZERO_ADDRESS!: T['Address']
 
+  // eslint-disable-next-line
+  public abstract Signer: new (signer: any) => AbstractSigner
   public abstract utils: AdapterUtils
 
   // Core functionality

--- a/packages/common/src/adapters/AbstractSigner.ts
+++ b/packages/common/src/adapters/AbstractSigner.ts
@@ -1,0 +1,13 @@
+import { TransactionParams, TransactionResponse } from './AbstractProviderAdapter'
+
+/**
+ * AbstractSignerAdapter defines the minimal interface that all signer-specific
+ * implementations must follow, focusing only on signing operations.
+ */
+export abstract class AbstractSigner {
+  abstract getAddress(): Promise<string>
+  abstract signMessage(message: string | Uint8Array): Promise<string>
+  abstract signTransaction(txParams: TransactionParams): Promise<string>
+  abstract signTypedData(domain: unknown, types: unknown, value: Record<string, unknown>): Promise<string>
+  abstract sendTransaction(txParams: TransactionParams): Promise<TransactionResponse>
+}

--- a/packages/common/src/adapters/index.ts
+++ b/packages/common/src/adapters/index.ts
@@ -1,4 +1,5 @@
 export * from './AbstractProviderAdapter'
+export * from './AbstractSigner'
 export * from './types'
 export * from './context'
 export * from './types'

--- a/packages/contracts-ts/src/ContractsTs.ts
+++ b/packages/contracts-ts/src/ContractsTs.ts
@@ -1,4 +1,4 @@
-import { AbstractProviderAdapter, AdapterTypes, setGlobalAdapter } from '@cowprotocol/common'
+import { AbstractProviderAdapter, setGlobalAdapter } from '@cowprotocol/common'
 import {
   hashify,
   normalizeBuyTokenBalance,
@@ -41,7 +41,7 @@ import {
 } from './settlement'
 import { encodeSwapStep, SwapEncoder } from './swap'
 
-export class ContractsTs<T extends AdapterTypes = AdapterTypes> {
+export class ContractsTs {
   // Make ORDER_TYPE_FIELDS and ORDER_UID_LENGTH available
   public ORDER_TYPE_FIELDS = ORDER_TYPE_FIELDS
   public ORDER_UID_LENGTH = ORDER_UID_LENGTH
@@ -116,7 +116,7 @@ export class ContractsTs<T extends AdapterTypes = AdapterTypes> {
    * signature.
    * @return An EIP-712 compatible typed domain data.
    */
-  public domain(chainId: number, verifyingContract: string): T['TypedDataDomain'] {
+  public static domain(chainId: number, verifyingContract: string) {
     return {
       name: 'Gnosis Protocol',
       version: 'v2',

--- a/packages/contracts-ts/src/sign.ts
+++ b/packages/contracts-ts/src/sign.ts
@@ -108,25 +108,14 @@ async function ecdsaSignTypedData(
 ): Promise<string> {
   let signature: string | null = null
   const adapter = getGlobalAdapter()
+  const signer = new adapter.Signer(owner)
 
   switch (scheme) {
     case SigningScheme.EIP712:
-      //@ts-expect-error signer type is unknown
-      if (owner?.signTypedData) {
-        //@ts-expect-error signer type is unknown
-        signature = await owner.signTypedData(domain, types, data)
-        break
-      }
-      //@ts-expect-error signer type is unknown
-      if (owner?._signTypedData) {
-        //@ts-expect-error signer type is unknown
-        signature = await owner._signTypedData(domain, types, data)
-        break
-      }
+      signature = await signer.signTypedData(domain, types, data)
       break
     case SigningScheme.ETHSIGN:
-      //@ts-expect-error signer type is unknown
-      signature = await owner.signMessage(adapter.utils.arrayify(adapter.utils.hashTypedData(domain, types, data)))
+      signature = await signer.signMessage(adapter.utils.arrayify(adapter.utils.hashTypedData(domain, types, data)))
       break
     default:
       throw new Error('invalid signing scheme')

--- a/packages/providers/ether-v5-adapter/src/EthersV5Adapter.ts
+++ b/packages/providers/ether-v5-adapter/src/EthersV5Adapter.ts
@@ -2,6 +2,7 @@ import { BigNumberish, BytesLike, ethers } from 'ethers'
 import type { TypedDataDomain, TypedDataField, TypedDataSigner } from '@ethersproject/abstract-signer'
 import { AbstractProviderAdapter, TransactionParams, TransactionResponse, AdapterTypes } from '@cowprotocol/sdk-common'
 import { EthersV5Utils } from './EthersV5Utils'
+import { EthersV5SignerAdapter } from './EthersV5SignerAdapter'
 
 type Abi = ConstructorParameters<typeof ethers.utils.Interface>[0]
 type Interface = ethers.utils.Interface
@@ -23,6 +24,7 @@ export class EthersV5Adapter extends AbstractProviderAdapter<EthersV5Types> {
 
   private provider: ethers.providers.Provider
   private signer: ethers.Signer & TypedDataSigner
+  public Signer = EthersV5SignerAdapter
   public utils: EthersV5Utils
 
   constructor(providerOrSigner: ethers.providers.Provider | ethers.Signer) {

--- a/packages/providers/ether-v5-adapter/src/EthersV5SignerAdapter.ts
+++ b/packages/providers/ether-v5-adapter/src/EthersV5SignerAdapter.ts
@@ -1,0 +1,83 @@
+import { Signer, BigNumber, TypedDataDomain, TypedDataField } from 'ethers'
+import { AbstractSigner, TransactionParams, TransactionResponse } from '@cowprotocol/common'
+import { TypedDataSigner } from '@ethersproject/abstract-signer'
+
+export class EthersV5SignerAdapter extends AbstractSigner {
+  private _signer: Signer & TypedDataSigner
+
+  constructor(signer: Signer & TypedDataSigner) {
+    super()
+    this._signer = signer
+  }
+
+  async getAddress(): Promise<string> {
+    return await this._signer.getAddress()
+  }
+
+  async signMessage(message: string | Uint8Array): Promise<string> {
+    return await this._signer.signMessage(message)
+  }
+
+  async signTransaction(txParams: TransactionParams): Promise<string> {
+    // Ethers v5 doesn't expose a direct signTransaction method on the Signer class
+    // This is a workaround using a private method, but might not work for all signers
+    if ('_signTransaction' in this._signer) {
+      return await this._signer.signTransaction(this._formatTxParams(txParams))
+    }
+    throw new Error('signTransaction not supported by this ethers v5 signer')
+  }
+
+  async signTypedData(
+    domain: TypedDataDomain,
+    types: Record<string, TypedDataField[]>,
+    value: Record<string, unknown>,
+  ): Promise<string> {
+    return await this._signer._signTypedData(domain, types, value)
+  }
+
+  async sendTransaction(txParams: TransactionParams): Promise<TransactionResponse> {
+    const tx = await this._signer.sendTransaction(this._formatTxParams(txParams))
+    return {
+      hash: tx.hash,
+      wait: async (confirmations?: number) => {
+        const receipt = await tx.wait(confirmations)
+        return {
+          transactionHash: receipt.transactionHash,
+          blockNumber: receipt.blockNumber,
+          blockHash: receipt.blockHash,
+          status: receipt.status,
+          gasUsed: BigInt(receipt.gasUsed.toString()),
+          logs: receipt.logs,
+        }
+      },
+    }
+  }
+
+  private _formatTxParams(txParams: TransactionParams) {
+    // Convert bigint values to BigNumber for ethers v5
+    // eslint-disable-next-line
+    const formatted: any = { ...txParams }
+
+    if (typeof formatted.value === 'bigint') {
+      formatted.value = BigNumber.from(formatted.value.toString())
+    }
+
+    if (typeof formatted.gasLimit === 'bigint') {
+      formatted.gasLimit = BigNumber.from(formatted.gasLimit.toString())
+    }
+
+    if (typeof formatted.gasPrice === 'bigint') {
+      formatted.gasPrice = BigNumber.from(formatted.gasPrice.toString())
+    }
+
+    if (typeof formatted.maxFeePerGas === 'bigint') {
+      formatted.maxFeePerGas = BigNumber.from(formatted.maxFeePerGas.toString())
+    }
+
+    if (typeof formatted.maxPriorityFeePerGas === 'bigint') {
+      formatted.maxPriorityFeePerGas = BigNumber.from(formatted.maxPriorityFeePerGas.toString())
+    }
+
+    return formatted
+  }
+}

--- a/packages/providers/ether-v6-adapter/src/EthersV6Adapter.ts
+++ b/packages/providers/ether-v6-adapter/src/EthersV6Adapter.ts
@@ -35,12 +35,14 @@ interface EthersV6Types extends AdapterTypes {
   TypedDataTypes: Record<string, TypedDataField[]>
 }
 import { EthersV6Utils } from './EthersV6Utils'
+import { EthersV6SignerAdapter } from './EthersV6SignerAdapter'
 
 export class EthersV6Adapter extends AbstractProviderAdapter<EthersV6Types> {
   declare protected _type?: EthersV6Types
 
   private provider: Provider
   private signer: Signer
+  public Signer = EthersV6SignerAdapter
   public utils: EthersV6Utils
 
   constructor(providerOrSigner: Provider | Signer) {

--- a/packages/providers/ether-v6-adapter/src/EthersV6SignerAdapter.ts
+++ b/packages/providers/ether-v6-adapter/src/EthersV6SignerAdapter.ts
@@ -1,0 +1,58 @@
+import { Log, Signer, TypedDataDomain, TypedDataField } from 'ethers'
+import { AbstractSigner, TransactionParams, TransactionResponse } from '@cowprotocol/common'
+
+export class EthersV6SignerAdapter extends AbstractSigner {
+  private _signer: Signer
+
+  constructor(signer: Signer) {
+    super()
+    this._signer = signer
+  }
+
+  async getAddress(): Promise<string> {
+    return await this._signer.getAddress()
+  }
+
+  async signMessage(message: string | Uint8Array): Promise<string> {
+    return await this._signer.signMessage(message)
+  }
+
+  async signTransaction(txParams: TransactionParams): Promise<string> {
+    return await this._signer.signTransaction(this._formatTxParams(txParams))
+  }
+
+  async signTypedData(
+    domain: TypedDataDomain,
+    types: Record<string, TypedDataField[]>,
+    value: Record<string, unknown>,
+  ): Promise<string> {
+    return await this._signer.signTypedData(domain, types, value)
+  }
+
+  async sendTransaction(txParams: TransactionParams): Promise<TransactionResponse> {
+    const tx = await this._signer.sendTransaction(this._formatTxParams(txParams))
+    return {
+      hash: tx.hash,
+      wait: async (confirmations?: number) => {
+        if (confirmations === null) throw new Error('unexpected')
+        const receipt = await tx.wait(confirmations)
+        if (!receipt) {
+          throw new Error('Transaction failed')
+        }
+        return {
+          transactionHash: receipt.hash,
+          blockNumber: receipt.blockNumber,
+          blockHash: receipt.blockHash || '',
+          status: receipt.status || 0,
+          gasUsed: receipt.gasUsed,
+          logs: receipt.logs as Log[],
+        }
+      },
+    }
+  }
+
+  private _formatTxParams(txParams: TransactionParams) {
+    // No need to convert bigint in ethers v6, as it's natively supported
+    return { ...txParams }
+  }
+}

--- a/packages/providers/viem-adapter/src/ViemAdapter.ts
+++ b/packages/providers/viem-adapter/src/ViemAdapter.ts
@@ -35,12 +35,14 @@ interface ViemTypes extends AdapterTypes {
   TypedDataTypes: Record<string, unknown>
 }
 import { ViemUtils } from './ViemUtils'
+import { ViemSignerAdapter } from './ViemSignerAdapter'
 
 export class ViemAdapter extends AbstractProviderAdapter<ViemTypes> {
   declare protected _type?: ViemTypes
   private publicClient: PublicClient
   private walletClient: WalletClient
   private account?: Account
+  public Signer = ViemSignerAdapter
   public utils: ViemUtils
 
   constructor(chain: Chain, transport: Transport = http(), account?: Account | `0x${string}`) {

--- a/packages/providers/viem-adapter/src/ViemSignerAdapter.ts
+++ b/packages/providers/viem-adapter/src/ViemSignerAdapter.ts
@@ -1,0 +1,115 @@
+import { Account, WalletClient, PublicClient, Address, TypedDataDomain, TypedDataParameter } from 'viem'
+import { AbstractSigner, TransactionParams, TransactionResponse } from '@cowprotocol/common'
+
+export class ViemSignerAdapter extends AbstractSigner {
+  private _client: WalletClient
+  private _account: Account
+  private _publicClient?: PublicClient
+
+  constructor(client: WalletClient) {
+    super()
+    this._client = client
+    if (!client?.account) throw new Error('Signer is missing account')
+    this._account = client.account
+  }
+
+  async getAddress(): Promise<string> {
+    return this._account.address
+  }
+
+  async signMessage(message: string | Uint8Array): Promise<string> {
+    if (typeof message === 'string') {
+      return await this._client.signMessage({
+        account: this._account,
+        message,
+      })
+    } else {
+      return await this._client.signMessage({
+        account: this._account,
+        message: { raw: message },
+      })
+    }
+  }
+
+  async signTransaction(txParams: TransactionParams): Promise<string> {
+    const formattedTx = this._formatTxParams(txParams)
+
+    return await this._client.signTransaction({
+      account: this._account,
+      ...formattedTx,
+    })
+  }
+
+  async signTypedData(
+    domain: TypedDataDomain,
+    types: Record<string, TypedDataParameter>,
+    value: Record<string, unknown>,
+  ): Promise<string> {
+    const primaryType = Object.keys(types)[0]
+
+    if (!primaryType) throw new Error('Missing primary type')
+
+    return await this._client.signTypedData({
+      account: this._account,
+      domain,
+      types,
+      primaryType, // Primary type is usually the first key in types
+      message: value,
+    })
+  }
+
+  async sendTransaction(txParams: TransactionParams): Promise<TransactionResponse> {
+    const formattedTx = this._formatTxParams(txParams)
+
+    const hash = await this._client.sendTransaction({
+      account: this._account,
+      ...formattedTx,
+    })
+
+    return {
+      hash,
+      wait: async (confirmations?: number) => {
+        if (!this._publicClient) {
+          throw new Error('Cannot wait for transaction without a public client')
+        }
+
+        const receipt = await this._publicClient.waitForTransactionReceipt({
+          hash,
+          confirmations,
+        })
+
+        return {
+          transactionHash: receipt.transactionHash,
+          blockNumber: Number(receipt.blockNumber),
+          blockHash: receipt.blockHash,
+          status: Number(receipt.status === 'success'),
+          gasUsed: receipt.gasUsed,
+          logs: receipt.logs,
+        }
+      },
+    }
+  }
+
+  private _formatTxParams(txParams: TransactionParams) {
+    // Convert to viem-specific format
+    //eslint-disable-next-line
+    const formatted: any = { ...txParams }
+
+    // Convert string addresses to Address type
+    if (formatted.to) {
+      formatted.to = formatted.to as Address
+    }
+
+    if (formatted.from) {
+      formatted.from = formatted.from as Address
+    }
+
+    // Ensure gas fields use the correct naming
+    if (formatted.gasLimit !== undefined) {
+      formatted.gas = formatted.gasLimit
+      delete formatted.gasLimit
+    }
+
+    return formatted
+  }
+}


### PR DESCRIPTION
Add a new signer adapter

The use case for this is when functions that receive signers as parameters (see `packages/contracts-ts/src/sign.ts` diffs). Without this dedicated signer adapter, the signer would different utilization across adapters. This way, the 'adaptation' is handled inside the framework-agnostic class (like ContractsTs)